### PR TITLE
Update UEyeCamera to work with USB3.0 Connection

### DIFF
--- a/assembly/assemblyCommon/AssemblyUEyeCamera.cc
+++ b/assembly/assemblyCommon/AssemblyUEyeCamera.cc
@@ -300,7 +300,7 @@ void AssemblyUEyeCamera::updatePixelClock()
     if (nRet == IS_SUCCESS) {
       nMin = nRange[0];
       nMax = nRange[1];
-      nInc = nRange[2];
+      nInc = nRange[2] ? nRange[2] : 1;
     }
 
     NQLog("AssemblyUEyeCamera", NQLog::Debug) << "updatePixelClock"


### PR DESCRIPTION
workaround to fix crash when using USB 3 ports. The issue arises from the is_PixelClock function returning an increment of zero on USB 3 connection.